### PR TITLE
Add three environment varaibles and their depends_on for UI Config

### DIFF
--- a/remote-monitoring/docker-compose.dotnet.yml
+++ b/remote-monitoring/docker-compose.dotnet.yml
@@ -63,8 +63,14 @@ services:
     image: azureiotpcs/pcs-ui-config-dotnet:latest
     depends_on:
       - storageadapter
+      - devicesimulation
+      - telemetry
+      - iothubmanager
     environment:
       - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter:9022/v1
+      - PCS_DEVICESIMULATION_WEBSERVICE_URL=http://devicesimulation:9003/v1
+      - PCS_DEVICETELEMETRY_WEBSERVICE_URL=http://telemetry:9004/v1
+      - PCS_IOTHUBMANAGER_WEBSERVICE_URL=http://iothubmanager:9002/v1
       - PCS_BINGMAP_KEY
 
   storageadapter:

--- a/remote-monitoring/docker-compose.java.yml
+++ b/remote-monitoring/docker-compose.java.yml
@@ -64,8 +64,14 @@ services:
     image: azureiotpcs/pcs-ui-config-java:latest
     depends_on:
       - storageadapter
+      - devicesimulation
+      - telemetry
+      - iothubmanager
     environment:
       - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter:9022/v1
+      - PCS_DEVICESIMULATION_WEBSERVICE_URL=http://devicesimulation:9003/v1
+      - PCS_DEVICETELEMETRY_WEBSERVICE_URL=http://telemetry:9004/v1
+      - PCS_IOTHUBMANAGER_WEBSERVICE_URL=http://iothubmanager:9002/v1
       - PCS_BINGMAP_KEY
 
   storageadapter:


### PR DESCRIPTION
Three environment variables are required by device twin cache feature.